### PR TITLE
Add Support For Laravel 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,36 +2,38 @@ name: Build
 
 on:
   push:
-    paths-ignore: ['*.md']
+    paths-ignore: ["*.md"]
   pull_request:
-    paths-ignore: [ '*.md' ]
-    branches: [ main, master ]
+    paths-ignore: ["*.md"]
+    branches: [main]
 
 jobs:
   analysis:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.2]
+        php: [8.3]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
           coverage: none
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: laravel-cacheable-analysis
         with:
-          path: ~/.composer
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist
       - name: Run static analysis
@@ -42,57 +44,63 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1]
+        php: [8.0, 8.1, 8.2]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
           coverage: none
       - name: Remove some dev dependencies
-        run: composer remove "ekino/phpstan-banned-code" "nunomaduro/larastan" "phpmd/phpmd" "phpstan/phpstan-deprecation-rules" "sebastian/phpcpd" --dev --no-update
+        run: composer remove "ekino/phpstan-banned-code" "larastan/larastan" "phpmd/phpmd" "phpstan/phpstan-deprecation-rules" --dev --no-update
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: laravel-cacheable-test
         with:
-          path: ~/.composer
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist
       - name: Run the test suite
         run: vendor/bin/phpunit
   test-coverage:
     name: Test (PHP ${{ matrix.php }})
-    needs: [ analysis ]
+    needs: [analysis]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 8.2 ]
+        php: [8.3]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
+      - name: Remove some dev dependencies
+        run: composer remove "ekino/phpstan-banned-code" "larastan/larastan" "phpmd/phpmd" "phpstan/phpstan-deprecation-rules" --dev --no-update
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: laravel-cacheable-test
         with:
-          path: ~/.composer
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist
       - name: Run the Coverage test suite

--- a/composer.json
+++ b/composer.json
@@ -20,22 +20,20 @@
         "source": "https://github.com/suitmedia/laravel-cacheable"
     },
     "require": {
-        "php": "^7.4|^8.0",
-        "illuminate/cache": "^8.0|^9.0|^10.0",
-        "illuminate/database": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0"
+        "php": "^8.0",
+        "illuminate/cache": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/database": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "ekino/phpstan-banned-code": "^1.0",
         "fakerphp/faker": "^1.14",
+        "larastan/larastan": "^1.0|^2.0",
         "mockery/mockery": "^1.4",
-        "nunomaduro/larastan": "^1.0|^2.0",
-        "orchestra/database": "^6.0|dev-master",
-        "orchestra/testbench": "^6.0|^7.0|^8.0",
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
         "phpmd/phpmd": "^2.11",
         "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpunit/phpunit": "^9.5",
-        "sebastian/phpcpd": "^6.0"
+        "phpunit/phpunit": "^9.5|^10.0|^11.0"
     },
     "config": {
         "sort-packages": true
@@ -65,8 +63,7 @@
         "analyse": [
             "composer check-syntax",
             "composer phpstan-analysis",
-            "composer phpmd-analysis",
-            "vendor/bin/phpcpd --min-lines=3 --min-tokens=36 src/"
+            "composer phpmd-analysis"
         ],
         "check-syntax": [
             "! find src -type f -name \"*.php\" -exec php -l {} \\; |  grep -v 'No syntax errors'",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - vendor/nunomaduro/larastan/extension.neon
+    - vendor/larastan/larastan/extension.neon
     - vendor/phpstan/phpstan-deprecation-rules/rules.neon
     - vendor/ekino/phpstan-banned-code/extension.neon
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Cacheable Test Suite">
       <directory suffix="Tests.php">./tests/</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,8 @@
-[![Build](https://github.com/suitmedia/laravel-cacheable/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/suitmedia/laravel-cacheable/actions/workflows/main.yml) 
-[![codecov](https://codecov.io/gh/suitmedia/laravel-cacheable/branch/master/graph/badge.svg)](https://codecov.io/gh/suitmedia/laravel-cacheable) 
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/suitmedia/laravel-cacheable/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/suitmedia/laravel-cacheable/?branch=master) 
-[![Total Downloads](https://poser.pugx.org/suitmedia/laravel-cacheable/d/total.svg)](https://packagist.org/packages/suitmedia/laravel-cacheable) 
-[![Latest Stable Version](https://poser.pugx.org/suitmedia/laravel-cacheable/v/stable.svg)](https://packagist.org/packages/suitmedia/laravel-cacheable) 
-[![License: MIT](https://poser.pugx.org/laravel/framework/license.svg)](https://opensource.org/licenses/MIT) 
+[![Build](https://github.com/suitmedia/laravel-cacheable/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/suitmedia/laravel-cacheable/actions/workflows/main.yml)
+[![codecov](https://codecov.io/gh/suitmedia/laravel-cacheable/branch/master/graph/badge.svg)](https://codecov.io/gh/suitmedia/laravel-cacheable)
+[![Total Downloads](https://poser.pugx.org/suitmedia/laravel-cacheable/d/total.svg)](https://packagist.org/packages/suitmedia/laravel-cacheable)
+[![Latest Stable Version](https://poser.pugx.org/suitmedia/laravel-cacheable/v/stable.svg)](https://packagist.org/packages/suitmedia/laravel-cacheable)
+[![License: MIT](https://poser.pugx.org/laravel/framework/license.svg)](https://opensource.org/licenses/MIT)
 
 # Laravel Cacheable
 
@@ -15,24 +14,25 @@ This package will help you to make your repositories cacheable without worrying 
 
 ## Table of contents
 
-* [Compatibility](#compatibility)
-* [Requirements](#requirements)
-* [Setup](#setup)
-* [Configuration](#configuration)
-* [Usage](#usage)
-* [License](#license)
+- [Compatibility](#compatibility)
+- [Requirements](#requirements)
+- [Setup](#setup)
+- [Configuration](#configuration)
+- [Usage](#usage)
+- [License](#license)
 
 ## Compatibility
 
- Laravel version   | Cacheable version
-:------------------|:-----------------
- 5.1.x - 5.4.x     | 1.0.x - 1.3.x
- 5.5.x - 5.8.x     | 1.4.x
- 6.x               | 1.5.x
- 7.x               | 1.6.x
- 8.x               | 1.7.x
- 9.x               | 1.9.x - 1.10.x
- 10.x              | 1.11.x
+| Laravel version | Cacheable version |
+| :-------------- | :---------------- |
+| 5.1.x - 5.4.x   | 1.0.x - 1.3.x     |
+| 5.5.x - 5.8.x   | 1.4.x             |
+| 6.x             | 1.5.x             |
+| 7.x             | 1.6.x             |
+| 8.x             | 1.7.x             |
+| 9.x             | 1.9.x - 1.10.x    |
+| 10.x            | 1.11.x            |
+| 11.x            | 1.12.x            |
 
 ## Requirements
 
@@ -41,6 +41,7 @@ This package require you to use cache storage which supports tags like memcached
 ## Setup
 
 Install the package via Composer :
+
 ```sh
 $ composer require suitmedia/laravel-cacheable
 ```
@@ -49,7 +50,7 @@ $ composer require suitmedia/laravel-cacheable
 
 ### Register The Service Provider
 
-Add the package service provider in your ``config/app.php``
+Add the package service provider in your `config/app.php`
 
 ```php
 'providers' => [
@@ -60,7 +61,7 @@ Add the package service provider in your ``config/app.php``
 
 ### Register The Package Alias
 
-Add the package alias in your ``config/app.php``
+Add the package alias in your `config/app.php`
 
 ```php
 'aliases' => [
@@ -71,13 +72,13 @@ Add the package alias in your ``config/app.php``
 
 ## Configuration
 
-Publish configuration file using ``php artisan`` command
+Publish configuration file using `php artisan` command
 
 ```sh
 $ php artisan vendor:publish --provider="Suitmedia\Cacheable\ServiceProvider"
 ```
 
-The command above would copy a new configuration file to ``/config/cacheable.php``
+The command above would copy a new configuration file to `/config/cacheable.php`
 
 ```php
 return [
@@ -181,7 +182,7 @@ class ArticleRepository implements CacheableRepository
     | Repository's method definition starts from here
     |--------------------------------------------------------------------------
     */
-    
+
     public function all()
     {
         return $this->model->all();
@@ -197,10 +198,10 @@ class ArticleRepository implements CacheableRepository
 #### Retrieve Data From Repository And Cache The Result
 
 With this package, you won't need to create new classes to decorate each of your repositories. You can just decorate them using the `Cacheable` facade, and all results of the repository's methods will be cached automatically.
- 
+
 ```php
 // Lets decorate the repository first
-$repo = \Cacheable::wrap(ArticleRepository::class);
+$repo = Cacheable::wrap(ArticleRepository::class);
 
 // The result of these codes will be cached automatically
 $repo->all();
@@ -215,14 +216,14 @@ But, you can also invalidate the cache manually using the `Cacheable` facade.
 
 ```php
 // Flush everything
-\Cacheable::flush();
+Cacheable::flush();
 
 // Flush the cache using a specific tag
-\Cacheable::flush('Article');
+Cacheable::flush('Article');
 
 // Flush the cache using a specific tag,
 // and only for the cache which belongs to a specific user
-\Cacheable::flush('LikedArticle:User:7');
+Cacheable::flush('LikedArticle:User:7');
 ```
 
 ## License

--- a/src/CacheableService.php
+++ b/src/CacheableService.php
@@ -8,6 +8,7 @@ use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Cache\TaggableStore;
 use Illuminate\Contracts\Cache\Store;
+use Illuminate\Support\Facades\App;
 use Suitmedia\Cacheable\Contracts\CacheableRepository;
 
 class CacheableService
@@ -151,7 +152,7 @@ class CacheableService
     public function wrap($repository): CacheableDecorator
     {
         if (is_string($repository)) {
-            $repository = \App::make($repository);
+            $repository = App::make($repository);
         }
 
         return $this->wrapWithDecorator($repository);

--- a/tests/CacheableEventTests.php
+++ b/tests/CacheableEventTests.php
@@ -2,6 +2,7 @@
 
 namespace Suitmedia\Cacheable\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Suitmedia\Cacheable\Events\CacheableInvalidating;
 use Suitmedia\Cacheable\Tests\Supports\Models\Video;
 
@@ -26,10 +27,10 @@ class CacheableEventTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
-        
+
         $this->model = new Video;
         $this->event = new CacheableInvalidating(
             $this->model,
@@ -38,7 +39,7 @@ class CacheableEventTests extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function return_affected_fields_correctly()
     {
         $actual = $this->event->affectedFields();
@@ -47,7 +48,7 @@ class CacheableEventTests extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function return_affected_model_correctly()
     {
         $actual = $this->event->model();
@@ -55,7 +56,7 @@ class CacheableEventTests extends TestCase
         $this->assertEquals($this->model, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function return_invalidate_tags_correctly()
     {
         $actual = $this->event->tags();

--- a/tests/DecoratorTests.php
+++ b/tests/DecoratorTests.php
@@ -3,6 +3,7 @@
 namespace Suitmedia\Cacheable\Tests;
 
 use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
 use Suitmedia\Cacheable\Tests\Supports\Models\Video;
 use Suitmedia\Cacheable\Tests\Supports\Repositories\VideoRepository;
 use Suitmedia\Cacheable\CacheableDecorator;
@@ -44,7 +45,7 @@ class DecoratorTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -55,7 +56,7 @@ class DecoratorTests extends TestCase
         $this->mockedRepository = \Mockery::mock(VideoRepository::class);
     }
 
-    /** @test */
+    #[Test]
     public function determine_if_the_method_argument_is_a_custom_tag_instance()
     {
         $this->assertFalse($this->invokeMethod(
@@ -77,7 +78,7 @@ class DecoratorTests extends TestCase
         ));
     }
 
-    /** @test */
+    #[Test]
     public function generate_the_custom_tags()
     {
         $tags = collect();
@@ -96,7 +97,7 @@ class DecoratorTests extends TestCase
         $this->assertEquals($expected, $tags->all());
     }
 
-    /** @test */
+    #[Test]
     public function generate_all_of_the_cache_tags_without_custom_tags()
     {
         $tags = $this->invokeMethod(
@@ -107,7 +108,7 @@ class DecoratorTests extends TestCase
         $this->assertEquals(['Video', 'VideoAlbum'], $tags);
     }
 
-    /** @test */
+    #[Test]
     public function generate_all_of_the_cache_tags_with_custom_tags()
     {
         $actual = $this->invokeMethod(
@@ -130,7 +131,7 @@ class DecoratorTests extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function recognize_any_method_that_should_be_cached()
     {
         $cacheable = $this->invokeMethod(
@@ -141,7 +142,7 @@ class DecoratorTests extends TestCase
         $this->assertEquals(true, $cacheable);
     }
 
-    /** @test */
+    #[Test]
     public function recognize_any_method_that_should_not_be_cached()
     {
         $cacheable = $this->invokeMethod(
@@ -152,7 +153,7 @@ class DecoratorTests extends TestCase
         $this->assertEquals(false, $cacheable);
     }
 
-    /** @test */
+    #[Test]
     public function return_exception_while_trying_to_access_undefined_method()
     {
         $this->expectException(MethodNotFoundException::class);
@@ -160,7 +161,7 @@ class DecoratorTests extends TestCase
         $this->decorator->getPhoneNumber();
     }
 
-    /** @test */
+    #[Test]
     public function execute_the_method_directly_if_it_is_not_cacheable()
     {
         $this->mockedRepository->shouldReceive('update')
@@ -178,7 +179,7 @@ class DecoratorTests extends TestCase
         $this->assertEquals('Video Updated', $result);
     }
 
-    /** @test */
+    #[Test]
     public function execute_the_method_once_if_it_is_cacheable()
     {
         $this->mockedRepository->shouldReceive('getAllVideos')
@@ -206,7 +207,7 @@ class DecoratorTests extends TestCase
         $this->assertEquals('All Videos', $result);
     }
 
-    /** @test */
+    #[Test]
     public function execute_the_method_once_even_if_it_returns_null()
     {
         $this->mockedRepository->shouldReceive('getAllVideos')
@@ -234,7 +235,7 @@ class DecoratorTests extends TestCase
         $this->assertNull($result);
     }
 
-    /** @test */
+    #[Test]
     public function execute_the_method_twice_if_it_got_flushed()
     {
         $tags = 'Video';

--- a/tests/EventTests.php
+++ b/tests/EventTests.php
@@ -3,13 +3,14 @@
 namespace Suitmedia\Cacheable\Tests;
 
 use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\Test;
 use Suitmedia\Cacheable\Events\CacheableInvalidated;
 use Suitmedia\Cacheable\Events\CacheableInvalidating;
 use Suitmedia\Cacheable\Tests\Supports\Models\Video;
 
 class EventTests extends TestCase
 {
-    /** @test */
+    #[Test]
     public function fire_cacheable_events_as_expected()
     {
         Event::fake([

--- a/tests/MethodNotFoundExceptionTests.php
+++ b/tests/MethodNotFoundExceptionTests.php
@@ -2,6 +2,7 @@
 
 namespace Suitmedia\Cacheable\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Suitmedia\Cacheable\Exceptions\MethodNotFoundException;
 
 class MethodNotFoundExceptionTests extends TestCase
@@ -18,13 +19,13 @@ class MethodNotFoundExceptionTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         $this->exception = (new MethodNotFoundException())
             ->setRepositoryMethod('VideoRepository', 'getAllVideos');
     }
 
-    /** @test */
+    #[Test]
     public function get_repository_class_name()
     {
         $className = $this->exception->getRepository();
@@ -32,7 +33,7 @@ class MethodNotFoundExceptionTests extends TestCase
         $this->assertEquals('VideoRepository', $className);
     }
 
-    /** @test */
+    #[Test]
     public function get_repository_method_name()
     {
         $methodName = $this->exception->getMethod();

--- a/tests/ModelTraitTests.php
+++ b/tests/ModelTraitTests.php
@@ -2,6 +2,7 @@
 
 namespace Suitmedia\Cacheable\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Suitmedia\Cacheable\Tests\Supports\Models\User;
 use Suitmedia\Cacheable\Tests\Supports\Models\Video;
 
@@ -26,7 +27,7 @@ class ModelTraitTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -34,7 +35,7 @@ class ModelTraitTests extends TestCase
         $this->videoModel = new Video;
     }
 
-    /** @test */
+    #[Test]
     public function get_default_cache_tags_value()
     {
         $tags = $this->videoModel->cacheTags();
@@ -42,7 +43,7 @@ class ModelTraitTests extends TestCase
         $this->assertEquals('Video', $tags);
     }
 
-    /** @test */
+    #[Test]
     public function get_overriden_cache_tags_value()
     {
         $tags = $this->userModel->cacheTags();

--- a/tests/ObservedModelTests.php
+++ b/tests/ObservedModelTests.php
@@ -2,6 +2,8 @@
 
 namespace Suitmedia\Cacheable\Tests;
 
+use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\Test;
 use Suitmedia\Cacheable\Tests\Supports\Models\Video;
 
 class ObservedModelTests extends TestCase
@@ -18,49 +20,49 @@ class ObservedModelTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->model = new Video;
 
-        \Cache::tags('Video')->put('foo', 'bar', 120);
+        Cache::tags('Video')->put('foo', 'bar', 120);
     }
 
-    /** @test */
+    #[Test]
     public function flush_cache_on_saving()
     {
         $video = Video::find(1);
         $video->title = 'Lorem Ipsum';
         $video->save();
 
-        $data = \Cache::tags('Video')->get('foo');
+        $data = Cache::tags('Video')->get('foo');
 
         $this->assertEquals(null, $data);
     }
 
-    /** @test */
+    #[Test]
     public function flush_cache_on_deleting()
     {
         Video::find(2)->delete();
 
-        $data = \Cache::tags('Video')->get('foo');
+        $data = Cache::tags('Video')->get('foo');
 
         $this->assertEquals(null, $data);
     }
 
-    /** @test */
+    #[Test]
     public function flush_cache_on_restoring_deleted_record()
     {
         Video::find(3)->delete();
-        \Cache::tags('Video')->put('foo', 'barbar', 120);
+        Cache::tags('Video')->put('foo', 'barbar', 120);
 
-        $data = \Cache::tags('Video')->get('foo');
+        $data = Cache::tags('Video')->get('foo');
         $this->assertEquals('barbar', $data);
 
         Video::withTrashed()->find(3)->restore();
 
-        $data = \Cache::tags('Video')->get('foo');
+        $data = Cache::tags('Video')->get('foo');
         $this->assertEquals(null, $data);
     }
 }

--- a/tests/RepositoryTraitTests.php
+++ b/tests/RepositoryTraitTests.php
@@ -2,6 +2,8 @@
 
 namespace Suitmedia\Cacheable\Tests;
 
+use Illuminate\Support\Facades\App;
+use PHPUnit\Framework\Attributes\Test;
 use Suitmedia\Cacheable\Tests\Supports\Repositories\UserRepository;
 use Suitmedia\Cacheable\Tests\Supports\Repositories\VideoRepository;
 
@@ -26,15 +28,15 @@ class RepositoryTraitTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
-        $this->userRepository = \App::make(UserRepository::class);
-        $this->videoRepository = \App::make(VideoRepository::class);
+        $this->userRepository = App::make(UserRepository::class);
+        $this->videoRepository = App::make(VideoRepository::class);
     }
 
-    /** @test */
+    #[Test]
     public function get_default_cache_duration_value_from_configuration()
     {
         $duration = (int) $this->videoRepository->cacheDuration();
@@ -42,7 +44,7 @@ class RepositoryTraitTests extends TestCase
         $this->assertEquals(0, $duration);
     }
 
-    /** @test */
+    #[Test]
     public function get_overriden_cache_duration_value()
     {
         $duration = (int) $this->userRepository->cacheDuration();
@@ -50,7 +52,7 @@ class RepositoryTraitTests extends TestCase
         $this->assertEquals(3600, $duration);
     }
 
-    /** @test */
+    #[Test]
     public function get_default_cache_except_value()
     {
         $actual = $this->videoRepository->cacheExcept();
@@ -70,7 +72,7 @@ class RepositoryTraitTests extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function get_overriden_cache_except_value()
     {
         $actual = $this->userRepository->cacheExcept();
@@ -84,7 +86,7 @@ class RepositoryTraitTests extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function get_default_cache_key_value()
     {
         $args = [
@@ -97,7 +99,7 @@ class RepositoryTraitTests extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function get_overriden_cache_key_value()
     {
         $actual = $this->userRepository->cacheKey('getMyVideo', null);
@@ -106,7 +108,7 @@ class RepositoryTraitTests extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function get_default_cache_tags_value_from_model_object()
     {
         $actual = $this->userRepository->cacheTags();
@@ -115,7 +117,7 @@ class RepositoryTraitTests extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function get_overriden_cache_tags_value()
     {
         $actual = $this->videoRepository->cacheTags();

--- a/tests/ServiceTests.php
+++ b/tests/ServiceTests.php
@@ -3,6 +3,7 @@
 namespace Suitmedia\Cacheable\Tests;
 
 use Illuminate\Cache\ArrayStore;
+use PHPUnit\Framework\Attributes\Test;
 use Suitmedia\Cacheable\Tests\Supports\Models\User;
 use Suitmedia\Cacheable\Tests\Supports\Models\Video;
 use Suitmedia\Cacheable\Tests\Supports\Repositories\VideoRepository;
@@ -29,7 +30,7 @@ class ServiceTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -37,7 +38,7 @@ class ServiceTests extends TestCase
         $this->service = new CacheableService(app('cache'), $this->runtimeCache);
     }
 
-    /** @test */
+    #[Test]
     public function build_decorator_object_by_class_name()
     {
         $decorator = $this->service->build(VideoRepository::class);
@@ -45,7 +46,7 @@ class ServiceTests extends TestCase
         $this->assertInstanceOf(CacheableDecorator::class, $decorator);
     }
 
-    /** @test */
+    #[Test]
     public function build_decorator_object_by_repository_object()
     {
         $repository = new VideoRepository(new Video);
@@ -54,7 +55,7 @@ class ServiceTests extends TestCase
         $this->assertInstanceOf(CacheableDecorator::class, $decorator);
     }
 
-    /** @test */
+    #[Test]
     public function flush_cache()
     {
         // Set runtime cache
@@ -75,7 +76,7 @@ class ServiceTests extends TestCase
         $this->assertEquals(null, $data);
     }
 
-    /** @test */
+    #[Test]
     public function runtime_cache_getter_and_setter()
     {
         // Set runtime cache
@@ -94,7 +95,7 @@ class ServiceTests extends TestCase
         $this->assertEquals('value', $data);
     }
 
-    /** @test */
+    #[Test]
     public function retrieve_data_from_runtime_cache()
     {
         $counter = 0;
@@ -108,7 +109,7 @@ class ServiceTests extends TestCase
         $this->assertEquals('Data 1', $data);
     }
 
-    /** @test */
+    #[Test]
     public function retrieve_data_from_cache_with_duration()
     {
         $counter = 0;
@@ -125,7 +126,7 @@ class ServiceTests extends TestCase
         $this->assertEquals('Data 1', $data);
     }
 
-    /** @test */
+    #[Test]
     public function retrieve_data_from_cache_without_duration()
     {
         $counter = 0;
@@ -142,7 +143,7 @@ class ServiceTests extends TestCase
         $this->assertEquals('Data 1', $data);
     }
 
-    /** @test */
+    #[Test]
     public function wrap_repository_with_decorator_object()
     {
         $repository = new VideoRepository(new Video);
@@ -155,7 +156,7 @@ class ServiceTests extends TestCase
         $this->assertInstanceOf(CacheableDecorator::class, $decorator);
     }
 
-    /** @test */
+    #[Test]
     public function execute_closure_when_the_tagged_cache_are_flushed()
     {
         $counter = 0;
@@ -172,7 +173,7 @@ class ServiceTests extends TestCase
         $this->assertEquals('Data 2', $data);
     }
 
-    /** @test */
+    #[Test]
     public function execute_closure_when_all_cache_are_flushed()
     {
         $counter = 0;

--- a/tests/Supports/Repositories/UserRepository.php
+++ b/tests/Supports/Repositories/UserRepository.php
@@ -11,17 +11,17 @@ class UserRepository extends EloquentRepository
 
     public function __construct(User $model)
     {
-        parent::__construct($model);    
+        parent::__construct($model);
     }
 
     public function getAllUsers()
     {
-        return $this->model->get();
+        return $this->model()->get();
     }
 
     public function getUser($UserId)
     {
-        return $this->model->find($UserId);
+        return $this->model()->find($UserId);
     }
 
     public function update($params)

--- a/tests/Supports/Repositories/VideoRepository.php
+++ b/tests/Supports/Repositories/VideoRepository.php
@@ -11,17 +11,17 @@ class VideoRepository extends EloquentRepository
 
     public function __construct(Video $model)
     {
-        parent::__construct($model);    
+        parent::__construct($model);
     }
 
     public function getAllVideos()
     {
-        return $this->model->get();
+        return $this->model()->get();
     }
 
     public function getVideo($videoId)
     {
-        return $this->model->find($videoId);
+        return $this->model()->find($videoId);
     }
 
     public function update($params)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -66,7 +66,6 @@ abstract class TestCase extends BaseTest
     {
         return [
             \Illuminate\Cache\CacheServiceProvider::class,
-            \Orchestra\Database\ConsoleServiceProvider::class,
             \Suitmedia\Cacheable\ServiceProvider::class,
         ];
     }
@@ -105,7 +104,7 @@ abstract class TestCase extends BaseTest
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
* Add support for Laravel 11
* Add support for PHP 8.3
* Drop support for PHP 7.4
* Update package dependencies
* Update PHP Unit configuration
* Update the test codes from using doc-comment metadata to use PHP 8 attribute
* Update Github actions workflow's configuration
* Update readme